### PR TITLE
wip: update for qt6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,9 +13,8 @@ include(FeatureSummary)
 include(GNUInstallDirs)
 
 set(QT_MIN_VERSION "5.11.0")
-find_package(Qt5 COMPONENTS Gui Qml Quick LinguistTools REQUIRED)
+find_package(Qt6 COMPONENTS Gui Qml Quick LinguistTools REQUIRED)
 find_package(Glacier 0.8.0 COMPONENTS App REQUIRED)
-find_package(Qt5QuickCompiler)
 find_package(PkgConfig)
 
 pkg_check_modules(PAMAC REQUIRED IMPORTED_TARGET pamac)
@@ -27,7 +26,7 @@ add_subdirectory(pamac)
 
 # Translations
 file(GLOB TS_FILES translations/*.ts)
-qt5_add_translation(QM_FILES ${TS_FILES})
+qt_add_translation(QM_FILES ${TS_FILES})
 add_custom_target(translations DEPENDS ${QM_FILES})
 add_dependencies(glacier-packagemanager translations)
 

--- a/pamac/CMakeLists.txt
+++ b/pamac/CMakeLists.txt
@@ -1,6 +1,6 @@
 ### Sets QT_INSTALL_QML to the directory where QML Plugins should be installed
 function(FindQtInstallQml)
-    find_program(QMAKE NAMES qmake-qt5 qmake)
+    find_program(QMAKE NAMES qmake6)
     if(NOT QMAKE)
     message(FATAL_ERROR "qmake not found")
     endif()
@@ -34,9 +34,9 @@ set(HEADERS
 add_library(glacierpackagemanager SHARED ${SRC})
 
 target_link_libraries(glacierpackagemanager
-    Qt5::Core
-    Qt5::Qml
-    Qt5::Quick
+    Qt6::Core
+    Qt6::Qml
+    Qt6::Quick
     PkgConfig::PAMAC
     PkgConfig::GLIB2
     PkgConfig::GOBJECT2)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,13 +2,13 @@ set(SRC main.cpp)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${XPACKAGEKIT_INCLUDE_DIRS})
 
-qtquick_compiler_add_resources(RESOURCES qml/glacier-pacmagemanager.qrc)
+qt_add_resources(RESOURCES qml/glacier-pacmagemanager.qrc)
 add_executable(glacier-packagemanager ${SRC} ${RESOURCES})
 
 target_link_libraries(glacier-packagemanager
-	Qt5::Gui
-	Qt5::Qml
-	Qt5::Quick
+	Qt6::Gui
+	Qt6::Qml
+	Qt6::Quick
         Glacier::App)
 
 install(TARGETS glacier-packagemanager RUNTIME

--- a/src/qml/components/HistoryItemDelegate.qml
+++ b/src/qml/components/HistoryItemDelegate.qml
@@ -17,12 +17,8 @@
  * Boston, MA 02110-1301, USA.
  */
 
-import QtQuick 2.6
-
-import QtQuick.Controls 1.0
-import QtQuick.Controls.Nemo 1.0
-import QtQuick.Controls.Styles.Nemo 1.0
-
+import QtQuick
+import Nemo.Controls
 
 ListViewItemWithActions {
     id: delegate

--- a/src/qml/components/PackageListDelegate.qml
+++ b/src/qml/components/PackageListDelegate.qml
@@ -17,12 +17,8 @@
  * Boston, MA 02110-1301, USA.
  */
 
-import QtQuick 2.6
-
-import QtQuick.Controls 1.0
-import QtQuick.Controls.Nemo 1.0
-import QtQuick.Controls.Styles.Nemo 1.0
-
+import QtQuick
+import Nemo.Controls
 
 ListViewItemWithActions {
     id: delegate

--- a/src/qml/glacier-packagemanager.qml
+++ b/src/qml/glacier-packagemanager.qml
@@ -17,11 +17,8 @@
  * Boston, MA 02110-1301, USA.
  */
 
-import QtQuick 2.6
-
-import QtQuick.Controls 1.0
-import QtQuick.Controls.Nemo 1.0
-import QtQuick.Controls.Styles.Nemo 1.0
+import QtQuick
+import Nemo.Controls
 
 import "pages"
 

--- a/src/qml/pages/AuthorizationFailPage.qml
+++ b/src/qml/pages/AuthorizationFailPage.qml
@@ -17,11 +17,8 @@
  * Boston, MA 02110-1301, USA.
  */
 
-import QtQuick 2.6
-
-import QtQuick.Controls 1.0
-import QtQuick.Controls.Nemo 1.0
-import QtQuick.Controls.Styles.Nemo 1.0
+import QtQuick
+import Nemo.Controls
 
 import "../components"
 

--- a/src/qml/pages/MainPage.qml
+++ b/src/qml/pages/MainPage.qml
@@ -17,11 +17,8 @@
  * Boston, MA 02110-1301, USA.
  */
 
-import QtQuick 2.6
-
-import QtQuick.Controls 1.0
-import QtQuick.Controls.Nemo 1.0
-import QtQuick.Controls.Styles.Nemo 1.0
+import QtQuick
+import Nemo.Controls
 
 import "../components"
 

--- a/src/qml/pages/OrphansPage.qml
+++ b/src/qml/pages/OrphansPage.qml
@@ -17,13 +17,9 @@
  * Boston, MA 02110-1301, USA.
  */
 
-import QtQuick 2.6
-
-import QtQuick.Controls 1.0
-import QtQuick.Controls.Nemo 1.0
-import QtQuick.Controls.Styles.Nemo 1.0
-
-import Nemo.Dialogs 1.0
+import QtQuick
+import Nemo.Controls
+import Nemo.Dialogs
 
 import "../components"
 

--- a/src/qml/pages/PackageInfoPage.qml
+++ b/src/qml/pages/PackageInfoPage.qml
@@ -17,11 +17,8 @@
  * Boston, MA 02110-1301, USA.
  */
 
-import QtQuick 2.6
-
-import QtQuick.Controls 1.0
-import QtQuick.Controls.Nemo 1.0
-import QtQuick.Controls.Styles.Nemo 1.0
+import QtQuick
+import Nemo.Controls
 
 Page {
     id: packageInfoPage

--- a/src/qml/pages/TransactionPage.qml
+++ b/src/qml/pages/TransactionPage.qml
@@ -17,11 +17,8 @@
  * Boston, MA 02110-1301, USA.
  */
 
-import QtQuick 2.6
-
-import QtQuick.Controls 1.0
-import QtQuick.Controls.Nemo 1.0
-import QtQuick.Controls.Styles.Nemo 1.0
+import QtQuick
+import Nemo.Controls
 
 Page {
     id: mainPage

--- a/src/qml/pages/UpdatesPage.qml
+++ b/src/qml/pages/UpdatesPage.qml
@@ -17,13 +17,9 @@
  * Boston, MA 02110-1301, USA.
  */
 
-import QtQuick 2.6
-
-import QtQuick.Controls 1.0
-import QtQuick.Controls.Nemo 1.0
-import QtQuick.Controls.Styles.Nemo 1.0
-
-import Nemo.Dialogs 1.0
+import QtQuick
+import Nemo.Controls
+import Nemo.Dialogs
 
 import "../components"
 


### PR DESCRIPTION
There is some issue to investigate:
```
[ 63%] Building CXX object pamac/CMakeFiles/glacierpackagemanager.dir/database.cpp.o
/home/jmlich/workspace/glacier-packagemanager/pamac/database.cpp: In constructor ‘DataBase::DataBase(QObject*)’:
/home/jmlich/workspace/glacier-packagemanager/pamac/database.cpp:32:5: error: ‘pamac_database_enable_appstream’ was not declared in this scope; did you mean ‘pamac_config_set_enable_appstream’?
   32 |     pamac_database_enable_appstream(m_pmDatabase);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |     pamac_config_set_enable_appstream
make[2]: *** [pamac/CMakeFiles/glacierpackagemanager.dir/build.make:104: pamac/CMakeFiles/glacierpackagemanager.dir/database.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:198: pamac/CMakeFiles/glacierpackagemanager.dir/all] Error 2
```